### PR TITLE
Adding pool address and tick index as separate fields in Tick

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -125,6 +125,10 @@ type Pool @entity {
 type Tick @entity {
   # format: <pool address>#<tick index>
   id: ID!
+  # pool address
+  poolAddress: String
+  # tick index
+  tickIdx: BigInt!
   # pointer to pool
   pool: Pool!
   # total liquidity pool has as tick lower or upper

--- a/schema.graphql
+++ b/schema.graphql
@@ -123,7 +123,7 @@ type Pool @entity {
 }
 
 type Tick @entity {
-  # format: <pool address>-<tick index>
+  # format: <pool address>#<tick index>
   id: ID!
   # pointer to pool
   pool: Pool!
@@ -175,7 +175,7 @@ type Transaction @entity {
 }
 
 type Mint @entity {
-  # transaction hash + "-" + index in mints Transaction array
+  # transaction hash + "#" + index in mints Transaction array
   id: ID!
   # which txn the mint was included in
   transaction: Transaction!
@@ -206,7 +206,7 @@ type Mint @entity {
 }
 
 type Burn @entity {
-  # transaction hash + "-" + index in mints Transaction array
+  # transaction hash + "#" + index in mints Transaction array
   id: ID!
   # txn burn was included in
   transaction: Transaction!
@@ -235,7 +235,7 @@ type Burn @entity {
 }
 
 type Swap @entity {
-  # transaction hash + "-" + index in swaps Transaction array
+  # transaction hash + "#" + index in swaps Transaction array
   id: ID!
   # pointer to transaction
   transaction: Transaction!
@@ -264,7 +264,7 @@ type Swap @entity {
 }
 
 type Collect @entity {
-  # transaction hash + "-" + index in collect Transaction array
+  # transaction hash + "#" + index in collect Transaction array
   id: ID!
   # pointer to txn
   transaction: Transaction!

--- a/src/utils/tick.ts
+++ b/src/utils/tick.ts
@@ -6,7 +6,9 @@ import { ONE_BD, ZERO_BD, ZERO_BI } from './constants';
 
 export function createTick(tickId: string, tickIdx: i32, poolId: string, event: MintEvent): Tick {
     let tick = new Tick(tickId);
+    tick.tickIdx = BigInt.fromI32(tickIdx)
     tick.pool = poolId;
+    tick.poolAddress = poolId;
 
     tick.createdAtTimestamp = event.block.timestamp
     tick.createdAtBlockNumber = event.block.number


### PR DESCRIPTION
This is so that we can filter on them when querying ticks.