### PR TITLE
Feature: Added support of tokens with static definitions

### DIFF
--- a/src/utils/staticTokenDefinition.ts
+++ b/src/utils/staticTokenDefinition.ts
@@ -1,0 +1,99 @@
+import {
+  Address,
+  BigInt,
+} from "@graphprotocol/graph-ts"
+  
+// Initialize a Token Definition with the attributes
+export class StaticTokenDefinition {
+  address : Address
+  symbol: string
+  name: string
+  decimals: BigInt
+
+  // Initialize a Token Definition with its attributes
+  constructor(address: Address, symbol: string, name: string, decimals: BigInt) {
+    this.address = address
+    this.symbol = symbol
+    this.name = name
+    this.decimals = decimals
+  }
+
+  // Get all tokens with a static defintion
+  static getStaticDefinitions(): Array<StaticTokenDefinition> {
+    let staticDefinitions = new Array<StaticTokenDefinition>(6)
+
+    // Add DGD
+    let tokenDGD = new StaticTokenDefinition(
+      Address.fromString('0xe0b7927c4af23765cb51314a0e0521a9645f0e2a'),
+      'DGD',
+      'DGD',
+      BigInt.fromI32(9)
+    )
+    staticDefinitions.push(tokenDGD)
+
+    // Add AAVE
+    let tokenAAVE = new StaticTokenDefinition(
+      Address.fromString('0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9'),
+      'AAVE',
+      'Aave Token',
+      BigInt.fromI32(18)
+    )
+    staticDefinitions.push(tokenAAVE)
+
+    // Add LIF
+    let tokenLIF = new StaticTokenDefinition(
+      Address.fromString('0xeb9951021698b42e4399f9cbb6267aa35f82d59d'),
+      'LIF',
+      'Lif',
+      BigInt.fromI32(18)
+    )
+    staticDefinitions.push(tokenLIF)
+
+    // Add SVD
+    let tokenSVD = new StaticTokenDefinition(
+      Address.fromString('0xbdeb4b83251fb146687fa19d1c660f99411eefe3'),
+      'SVD',
+      'savedroid',
+      BigInt.fromI32(18)
+    )
+    staticDefinitions.push(tokenSVD)
+
+    // Add TheDAO
+    let tokenTheDAO = new StaticTokenDefinition(
+      Address.fromString('0xbb9bc244d798123fde783fcc1c72d3bb8c189413'),
+      'TheDAO',
+      'TheDAO',
+      BigInt.fromI32(16)
+    )
+    staticDefinitions.push(tokenTheDAO)
+
+    // Add HPB
+    let tokenHPB = new StaticTokenDefinition(
+      Address.fromString('0x38c6a68304cdefb9bec48bbfaaba5c5b47818bb2'),
+      'HPB',
+      'HPBCoin',
+      BigInt.fromI32(18)
+    )
+    staticDefinitions.push(tokenHPB)
+
+    return staticDefinitions
+  }
+
+  // Helper for hardcoded tokens
+  static fromAddress(tokenAddress: Address) : StaticTokenDefinition | null {
+    let staticDefinitions = this.getStaticDefinitions()
+    let tokenAddressHex = tokenAddress.toHexString()
+
+    // Search the definition using the address
+    for (let i = 0; i < staticDefinitions.length; i++) {
+      let staticDefinition = staticDefinitions[i]
+      if(staticDefinition.address.toHexString() == tokenAddressHex) {
+        return staticDefinition
+      }
+    }
+
+    // If not found, return null
+    return null
+  }
+
+}

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -2,6 +2,7 @@
 import { ERC20 } from '../types/Factory/ERC20'
 import { ERC20SymbolBytes } from '../types/Factory/ERC20SymbolBytes'
 import { ERC20NameBytes } from '../types/Factory/ERC20NameBytes'
+import { StaticTokenDefinition } from './staticTokenDefinition'
 import { BigInt, Address } from '@graphprotocol/graph-ts'
 import { isNullEthValue } from '.'
 
@@ -18,6 +19,12 @@ export function fetchTokenSymbol(tokenAddress: Address): string {
       // for broken pairs that have no symbol function exposed
       if (!isNullEthValue(symbolResultBytes.value.toHexString())) {
         symbolValue = symbolResultBytes.value.toString()
+      } else {
+        // try with the static definition
+        let staticTokenDefinition = StaticTokenDefinition.fromAddress(tokenAddress)
+        if(staticTokenDefinition != null) {
+          symbolValue = staticTokenDefinition.symbol
+        }
       }
     }
   } else {
@@ -40,6 +47,12 @@ export function fetchTokenName(tokenAddress: Address): string {
       // for broken exchanges that have no name function exposed
       if (!isNullEthValue(nameResultBytes.value.toHexString())) {
         nameValue = nameResultBytes.value.toString()
+      } else {
+        // try with the static definition
+        let staticTokenDefinition = StaticTokenDefinition.fromAddress(tokenAddress)
+        if(staticTokenDefinition != null) {
+          nameValue = staticTokenDefinition.name
+        }
       }
     }
   } else {
@@ -66,6 +79,12 @@ export function fetchTokenDecimals(tokenAddress: Address): BigInt {
   let decimalResult = contract.try_decimals()
   if (!decimalResult.reverted) {
     decimalValue = decimalResult.value
+  } else {
+    // try with the static definition
+    let staticTokenDefinition = StaticTokenDefinition.fromAddress(tokenAddress)
+    if(staticTokenDefinition != null) {
+      return staticTokenDefinition.decimals
+    }
   }
 
   return BigInt.fromI32(decimalValue as i32)


### PR DESCRIPTION
Hello,

Some ERC20 Tokens are reverting on `name()`, `decimals()` or `symbol()` as these functions are optional in the ERC20 Token. 
This request adds the support in Uniswap V3 of static definitions as suggested in the [PR #86](https://github.com/Uniswap/uniswap-v2-subgraph/pull/86) in Uniswap V2 subgraph.

I deployed this subgraph in Rinkeby: [here](https://thegraph.com/explorer/subgraph/mtahon/uniswap-v3-rinkeby) and it is has synced without issues. All tests where done on the mentioned PR using Uniswap V2 data.

Thanks for considering it.

Best regards
Mathieu
