### PR TITLE
feat: fee vars and position snaps

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -184,6 +184,9 @@ type Tick @entity {
   liquidityProviderCount: BigInt! # used to detect new exchanges
   # derived fields
   # swaps: [Swap!]! @derivedFrom(field: "tick")
+  # vars needed for fee computation
+  feeGrowthOutside0X128: BigInt!
+  feeGrowthOutside1X128: BigInt!
 }
 
 type Position @entity {
@@ -218,6 +221,43 @@ type Position @entity {
   collectedFeesToken1: BigDecimal!
   # tx in which the position was initialized
   transaction: Transaction!
+  # vars needed for fee computation
+  feeGrowthInside0LastX128: BigInt!
+  feeGrowthInside1LastX128: BigInt!
+}
+
+type PositionSnapshot @entity {
+  # <NFT token id>#<block number>
+  id: ID!
+  # owner of the NFT
+  owner: Bytes!
+  # pool the position is within
+  pool: Pool!
+  # position of which the snap was taken of
+  position: Position!
+  # block in which the snap was created
+  blockNumber: BigInt!
+  # timestamp of block in which the snap was created
+  timestamp: BigInt!
+  # total position liquidity
+  liquidity: BigInt!
+  # amount of token 0 ever deposited to position
+  depositedToken0: BigDecimal!
+  # amount of token 1 ever deposited to position
+  depositedToken1: BigDecimal!
+  # amount of token 0 ever withdrawn from position (without fees)
+  withdrawnToken0: BigDecimal!
+  # amount of token 1 ever withdrawn from position (without fees)
+  withdrawnToken1: BigDecimal!
+  # all time collected fees in token0
+  collectedFeesToken0: BigDecimal!
+  # all time collected fees in token1
+  collectedFeesToken1: BigDecimal!
+  # tx in which the snapshot was initialized
+  transaction: Transaction!
+  # internal vars needed for fee computation
+  feeGrowthInside0LastX128: BigInt!
+  feeGrowthInside1LastX128: BigInt!
 }
 
 type Transaction @entity {
@@ -509,9 +549,9 @@ type TickHourData @entity {
   # pointer to tick
   tick: Tick!
   # total liquidity pool has as tick lower or upper at end of period
-  liquidityGross: BigDecimal!
+  liquidityGross: BigInt!
   # how much liquidity changes when tick crossed at end of period
-  liquidityNet: BigDecimal!
+  liquidityNet: BigInt!
   # hourly volume of token0 with this tick in range
   volumeToken0: BigDecimal!
   # hourly volume of token1 with this tick in range
@@ -523,6 +563,7 @@ type TickHourData @entity {
 }
 
 # Data accumulated and condensed into day stats for each exchange
+# Note: this entity gets saved only if there is a change during the day
 type TickDayData @entity {
   # format: <pool address>-<tick index>-<timestamp>
   id: ID!
@@ -533,9 +574,9 @@ type TickDayData @entity {
   # pointer to tick
   tick: Tick!
   # total liquidity pool has as tick lower or upper at end of period
-  liquidityGross: BigDecimal!
+  liquidityGross: BigInt!
   # how much liquidity changes when tick crossed at end of period
-  liquidityNet: BigDecimal!
+  liquidityNet: BigInt!
   # hourly volume of token0 with this tick in range
   volumeToken0: BigDecimal!
   # hourly volume of token1 with this tick in range
@@ -544,6 +585,9 @@ type TickDayData @entity {
   volumeUSD: BigDecimal!
   # fees in USD
   feesUSD: BigDecimal!
+  # vars needed for fee computation
+  feeGrowthOutside0X128: BigInt!
+  feeGrowthOutside1X128: BigInt!
 }
 
 type TokenDayData @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -202,9 +202,9 @@ type Position @entity {
   # allow indexing by tokens
   token1: Token!
   # lower tick of the position
-  tickLower: BigInt!
+  tickLower: Tick!
   # upper tick of the position
-  tickUpper: BigInt!
+  tickUpper: Tick!
   # total position liquidity
   liquidity: BigInt!
   # amount of token 0 ever deposited to position

--- a/src/mappings/core.ts
+++ b/src/mappings/core.ts
@@ -254,20 +254,8 @@ export function handleBurn(event: BurnEvent): void {
   updateTokenDayData(token1 as Token, event)
   updateTokenHourData(token0 as Token, event)
   updateTokenHourData(token1 as Token, event)
-
-  // If liquidity gross is zero then there are no positions starting at or ending at the tick.
-  // It is now safe to remove the tick from the data store.
-  if (lowerTick.liquidityGross.equals(ZERO_BI)) {
-    store.remove('Tick', lowerTickId)
-  } else {
-    updateTickFeeVarsAndSave(lowerTick!, event)
-  }
-
-  if (upperTick.liquidityGross.equals(ZERO_BI)) {
-    store.remove('Tick', upperTickId)
-  } else {
-    updateTickFeeVarsAndSave(upperTick!, event)
-  }
+  updateTickFeeVarsAndSave(lowerTick!, event)
+  updateTickFeeVarsAndSave(upperTick!, event)
 
   token0.save()
   token1.save()

--- a/src/mappings/position-manager.ts
+++ b/src/mappings/position-manager.ts
@@ -31,8 +31,8 @@ function getPosition(event: ethereum.Event, tokenId: BigInt): Position | null {
       position.pool = poolAddress.toHexString()
       position.token0 = positionResult.value2.toHexString()
       position.token1 = positionResult.value3.toHexString()
-      position.tickLower = BigInt.fromI32(positionResult.value5)
-      position.tickUpper = BigInt.fromI32(positionResult.value6)
+      position.tickLower = position.pool.concat('#').concat(positionResult.value5.toString())
+      position.tickUpper = position.pool.concat('#').concat(positionResult.value6.toString())
       position.liquidity = ZERO_BI
       position.depositedToken0 = ZERO_BD
       position.depositedToken1 = ZERO_BD

--- a/src/mappings/position-manager.ts
+++ b/src/mappings/position-manager.ts
@@ -6,7 +6,7 @@ import {
   NonfungiblePositionManager,
   Transfer
 } from '../types/NonfungiblePositionManager/NonfungiblePositionManager'
-import { Position, Token } from '../types/schema'
+import { Position, PositionSnapshot, Token } from '../types/schema'
 import { ADDRESS_ZERO, factoryContract, ZERO_BD, ZERO_BI } from '../utils/constants'
 import { Address, BigInt, ethereum } from '@graphprotocol/graph-ts'
 import { convertTokenToDecimal, loadTransaction } from '../utils'
@@ -17,6 +17,10 @@ function getPosition(event: ethereum.Event, tokenId: BigInt): Position | null {
     let contract = NonfungiblePositionManager.bind(event.address)
     let positionCall = contract.try_positions(tokenId)
 
+    // the following call reverts in situations where the position is minted
+    // and deleted in the same block - from my investigation this happens
+    // in calls from  BancorSwap
+    // (e.g. 0xf7867fa19aa65298fadb8d4f72d0daed5e836f3ba01f0b9b9631cdc6c36bed40)
     if (!positionCall.reverted) {
       let positionResult = positionCall.value
       let poolAddress = factoryContract.getPool(positionResult.value2, positionResult.value3, positionResult.value4)
@@ -37,10 +41,42 @@ function getPosition(event: ethereum.Event, tokenId: BigInt): Position | null {
       position.collectedFeesToken0 = ZERO_BD
       position.collectedFeesToken1 = ZERO_BD
       position.transaction = loadTransaction(event).id
+      position.feeGrowthInside0LastX128 = positionResult.value8
+      position.feeGrowthInside1LastX128 = positionResult.value9
     }
   }
 
-  return position!
+  return position
+}
+
+function updateFeeVars(position: Position, event: ethereum.Event, tokenId: BigInt): Position {
+  let positionManagerContract = NonfungiblePositionManager.bind(event.address)
+  let positionResult = positionManagerContract.try_positions(tokenId)
+  if (!positionResult.reverted) {
+    position.feeGrowthInside0LastX128 = positionResult.value.value8
+    position.feeGrowthInside1LastX128 = positionResult.value.value9
+  }
+  return position
+}
+
+function savePositionSnapshot(position: Position, event: ethereum.Event): void {
+  let positionSnapshot = new PositionSnapshot(position.id.concat('#').concat(event.block.number.toString()))
+  positionSnapshot.owner = position.owner
+  positionSnapshot.pool = position.pool
+  positionSnapshot.position = position.id
+  positionSnapshot.blockNumber = event.block.number
+  positionSnapshot.timestamp = event.block.timestamp
+  positionSnapshot.liquidity = position.liquidity
+  positionSnapshot.depositedToken0 = position.depositedToken0
+  positionSnapshot.depositedToken1 = position.depositedToken1
+  positionSnapshot.withdrawnToken0 = position.withdrawnToken0
+  positionSnapshot.withdrawnToken1 = position.withdrawnToken1
+  positionSnapshot.collectedFeesToken0 = position.collectedFeesToken0
+  positionSnapshot.collectedFeesToken1 = position.collectedFeesToken1
+  positionSnapshot.transaction = loadTransaction(event).id
+  positionSnapshot.feeGrowthInside0LastX128 = position.feeGrowthInside0LastX128
+  positionSnapshot.feeGrowthInside1LastX128 = position.feeGrowthInside1LastX128
+  positionSnapshot.save()
 }
 
 export function handleIncreaseLiquidity(event: IncreaseLiquidity): void {
@@ -66,7 +102,11 @@ export function handleIncreaseLiquidity(event: IncreaseLiquidity): void {
   position.depositedToken0 = position.depositedToken0.plus(amount0)
   position.depositedToken1 = position.depositedToken1.plus(amount1)
 
+  updateFeeVars(position!, event, event.params.tokenId)
+
   position.save()
+
+  savePositionSnapshot(position!, event)
 }
 
 export function handleDecreaseLiquidity(event: DecreaseLiquidity): void {
@@ -91,7 +131,11 @@ export function handleDecreaseLiquidity(event: DecreaseLiquidity): void {
   position.withdrawnToken0 = position.withdrawnToken0.plus(amount0)
   position.withdrawnToken1 = position.withdrawnToken1.plus(amount1)
 
+  position = updateFeeVars(position!, event, event.params.tokenId)
+
   position.save()
+
+  savePositionSnapshot(position!, event)
 }
 
 export function handleCollect(event: Collect): void {
@@ -113,7 +157,12 @@ export function handleCollect(event: Collect): void {
   let amount1 = convertTokenToDecimal(event.params.amount1, token1.decimals)
   position.collectedFeesToken0 = position.collectedFeesToken0.plus(amount0)
   position.collectedFeesToken1 = position.collectedFeesToken1.plus(amount1)
+
+  position = updateFeeVars(position!, event, event.params.tokenId)
+
   position.save()
+
+  savePositionSnapshot(position!, event)
 }
 
 export function handleTransfer(event: Transfer): void {
@@ -126,4 +175,6 @@ export function handleTransfer(event: Transfer): void {
 
   position.owner = event.params.to
   position.save()
+
+  savePositionSnapshot(position!, event)
 }

--- a/src/utils/intervalUpdates.ts
+++ b/src/utils/intervalUpdates.ts
@@ -9,7 +9,9 @@ import {
   TokenDayData,
   TokenHourData,
   Bundle,
-  PoolHourData
+  PoolHourData,
+  TickDayData,
+  Tick
 } from './../types/schema'
 import { FACTORY_ADDRESS } from './constants'
 import { ethereum } from '@graphprotocol/graph-ts'
@@ -222,4 +224,30 @@ export function updateTokenHourData(token: Token, event: ethereum.Event): TokenH
   tokenHourData.save()
 
   return tokenHourData as TokenHourData
+}
+
+export function updateTickDayData(tick: Tick, event: ethereum.Event): TickDayData {
+  let timestamp = event.block.timestamp.toI32()
+  let dayID = timestamp / 86400
+  let dayStartTimestamp = dayID * 86400
+  let dayTickID = tick.id.concat('-').concat(dayID.toString())
+  let tickDayData = TickDayData.load(dayTickID)
+  if (tickDayData === null) {
+    tickDayData = new TickDayData(dayTickID)
+    tickDayData.date = dayStartTimestamp
+    tickDayData.pool = tick.pool
+  }
+  tickDayData.tick = tick.id
+  tickDayData.liquidityGross = tick.liquidityGross
+  tickDayData.liquidityNet = tick.liquidityNet
+  tickDayData.volumeToken0 = tick.volumeToken0
+  tickDayData.volumeToken1 = tick.volumeToken0
+  tickDayData.volumeUSD = tick.volumeUSD
+  tickDayData.feesUSD = tick.feesUSD
+  tickDayData.feeGrowthOutside0X128 = tick.feeGrowthOutside0X128
+  tickDayData.feeGrowthOutside1X128 = tick.feeGrowthOutside1X128
+
+  tickDayData.save()
+
+  return tickDayData as TickDayData
 }

--- a/src/utils/tick.ts
+++ b/src/utils/tick.ts
@@ -34,6 +34,8 @@ export function createTick(tickId: string, tickIdx: i32, poolId: string, event: 
   tick.collectedFeesToken1 = ZERO_BD
   tick.collectedFeesUSD = ZERO_BD
   tick.liquidityProviderCount = ZERO_BI
+  tick.feeGrowthOutside0X128 = ZERO_BI
+  tick.feeGrowthOutside1X128 = ZERO_BI
 
   return tick
 }

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -96,3 +96,5 @@ templates:
           handler: handleMint
         - event: Burn(indexed address,indexed int24,indexed int24,uint128,uint256,uint256)
           handler: handleBurn
+        - event: Flash(indexed address,indexed address,uint256,uint256,uint256,uint256)
+          handler: handleFlash


### PR DESCRIPTION
Hello,
I have implemented a functionality necessary to track the fees directly from subgraph data (instead of by doing contract calls).

The subgraph is currently syncing [here](https://thegraph.com/explorer/subgraph/benesjan/uniswap-v3-test?version=pending).
It would make sense to wait if it syncs fully without failing. I sent the PR now in order to avoid duplicate work by other people.

[Here](https://github.com/croco-finance/data-fetching/blob/master/src/fees/total-owner-pool-fees.ts) is an example implementation of how the data can be used to compute fees on a position. I tested the code [here](https://github.com/croco-finance/data-fetching/blob/master/src/fees/fees.test.ts) and the total fees matched precisely the values obtained from the contracts. (I tested this on my subgraph before the sync failed due to a bug which was fixed in PR #15 ).

The code is a bit hacky in some places but this was a necessary tradeoff due to the limitations of subgraph's API when the data is not exposed through events (e.g. [here](https://github.com/croco-finance/uniswap-v3-subgraph/blob/bdd195f0e3f7e688548f5ddebd051ce37074a431/src/mappings/core.ts#L488) I was forced to limit the number of tick updates within one swap which can cause imprecision right after the pool is initialized).

Best regards,
Jan