### PR TITLE
Get correct ETH/USDC price on Arbitrum

### DIFF
--- a/src/utils/pricing.ts
+++ b/src/utils/pricing.ts
@@ -30,9 +30,9 @@ export function sqrtPriceX96ToTokenPrices(sqrtPriceX96: BigInt, token0: Token, t
 
 export function getEthPriceInUSD(): BigDecimal {
   // fetch eth prices for each stablecoin
-  let usdcPool = Pool.load(USDC_WETH_03_POOL) // dai is token0
+  let usdcPool = Pool.load(USDC_WETH_03_POOL) // USDC is token1
   if (usdcPool !== null) {
-    return usdcPool.token0Price
+    return usdcPool.token1Price
   } else {
     return ZERO_BD
   }


### PR DESCRIPTION
USDC is token1, not token0 on Arbitrum